### PR TITLE
fix(npm): Remove .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,0 @@
-twilio.env
-sendgrid.env
-src/
-server/
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@boklisten/bl-post-office",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boklisten/bl-post-office",
-  "version": "0.5.43",
+  "version": "0.5.44",
   "description": "a single module for sending messages to a customer",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
The presence of the .npmignore-file caused npm to ignore the gitignore,
causing it to publish the .env-file which was gitignored but not
npmignored, leaking secrets. Removing this file causes npm to use
gitignore, preventing this problem in the future. caused npm to ignore
the gitignore, causing it to publish the .env-file which was gitignored
but not npmignored, leaking secrets. Removing this file causes npm to
use gitignore, preventing this problem in the future.
